### PR TITLE
Improved taxation in multiplayer when using shared wallets

### DIFF
--- a/Modular Gameplay Overhaul/Modules/OverhaulModule.cs
+++ b/Modular Gameplay Overhaul/Modules/OverhaulModule.cs
@@ -242,6 +242,9 @@ internal abstract class OverhaulModule : SmartEnum<OverhaulModule>
         /// <summary>Gets the ephemeral runtime state for the <see cref="OverhaulModule.TaxesModule"/>.</summary>
         internal static Taxes.State State => ModEntry.State.Taxes;
 
+        /// <summary>Gets a value indicating whether the current player should pay taxes.</summary>
+        internal static bool PlayerShouldPayTaxes => Game1.player.useSeparateWallets || !Context.IsMultiplayer || Context.IsMainPlayer;
+
         /// <inheritdoc />
         protected override void InvalidateAssets()
         {

--- a/Modular Gameplay Overhaul/Modules/Taxes/Events/FarmhandTaxInfoModMessageReceivedEvent.cs
+++ b/Modular Gameplay Overhaul/Modules/Taxes/Events/FarmhandTaxInfoModMessageReceivedEvent.cs
@@ -1,0 +1,48 @@
+﻿namespace DaLion.Overhaul.Modules.Taxes.Events;
+
+#region using directives
+
+using DaLion.Shared.Events;
+using DaLion.Shared.Extensions.Stardew;
+using StardewModdingAPI.Events;
+using StardewValley;
+
+#endregion using directives
+
+[UsedImplicitly]
+internal sealed class FarmhandTaxInfoModMessageReceivedEvent : ModMessageReceivedEvent
+{
+    /// <summary>Initializes a new instance of the <see cref="FarmhandTaxInfoModMessageReceivedEvent"/> class.</summary>
+    /// <param name="manager">The <see cref="EventManager"/> instance that manages this event.</param>
+    internal FarmhandTaxInfoModMessageReceivedEvent(EventManager manager)
+        : base(manager)
+    {
+    }
+
+    /// <inheritdoc />
+    public override bool IsEnabled => Context.IsMultiplayer && Context.IsMainPlayer;
+
+    /// <inheritdoc />
+    protected override void OnModMessageReceivedImpl(object? sender, ModMessageReceivedEventArgs e)
+    {
+        if (string.Compare(e.Type?[..6], "Taxes.") != 0)
+        {
+            return;
+        }
+
+        var field = e?.Type?[6..];
+        if (string.IsNullOrWhiteSpace(field))
+        {
+            return;
+        }
+
+        var money = e?.ReadAs<int>() ?? 0;
+        if (money == 0)
+        {
+            return;
+        }
+
+        Log.I($"A farmhand has incremented {Game1.player.Name}'s {field} by {money}.");
+        Game1.player.Increment(field, money);
+    }
+}

--- a/Modular Gameplay Overhaul/Modules/Taxes/Events/TaxDayEndingEvent.cs
+++ b/Modular Gameplay Overhaul/Modules/Taxes/Events/TaxDayEndingEvent.cs
@@ -29,6 +29,16 @@ internal sealed class TaxDayEndingEvent : DayEndingEvent
     {
         var player = Game1.player;
 
+        if (!TaxesModule.PlayerShouldPayTaxes)
+        {
+            // only for non-taxable farmhands; clear data just in case any outdated info is there
+            player.Write(DataFields.SeasonIncome, "0");
+            player.Write(DataFields.BusinessExpenses, "0");
+            player.Write(DataFields.DebtOutstanding, "0");
+            player.Write(DataFields.PercentDeductions, "0");
+            return;
+        }
+
         if (Game1.dayOfMonth == 0 && Game1.currentSeason == "spring" && Game1.year == 1)
         {
             player.mailForTomorrow.Add($"{Manifest.UniqueID}/TaxIntro");

--- a/Modular Gameplay Overhaul/Modules/Taxes/Patchers/BluePrintConsumeResourcesPatcher.cs
+++ b/Modular Gameplay Overhaul/Modules/Taxes/Patchers/BluePrintConsumeResourcesPatcher.cs
@@ -28,7 +28,14 @@ internal sealed class BluePrintConsumeResourcesPatcher : HarmonyPatcher
             return;
         }
 
-        Game1.player.Increment(DataFields.BusinessExpenses, __instance.moneyRequired);
+        if (TaxesModule.PlayerShouldPayTaxes)
+        {
+            Game1.player.Increment(DataFields.BusinessExpenses, __instance.moneyRequired);
+        }
+        else
+        {
+            ModEntry.Broadcaster.MessageHost(__instance.moneyRequired.ToString(), "Taxes." + DataFields.BusinessExpenses);
+        }
     }
 
     #endregion harmony patches

--- a/Modular Gameplay Overhaul/Modules/Taxes/Patchers/PurchaseAnimalsSetUpForReturnAfterPurchasingAnimalPatcher.cs
+++ b/Modular Gameplay Overhaul/Modules/Taxes/Patchers/PurchaseAnimalsSetUpForReturnAfterPurchasingAnimalPatcher.cs
@@ -5,6 +5,7 @@
 using DaLion.Shared.Extensions.Stardew;
 using DaLion.Shared.Harmony;
 using HarmonyLib;
+using StardewValley;
 using StardewValley.Menus;
 
 #endregion using directives
@@ -29,7 +30,14 @@ internal sealed class PurchaseAnimalsSetUpForReturnAfterPurchasingAnimalPatcher 
             return;
         }
 
-        Game1.player.Increment(DataFields.BusinessExpenses, ___priceOfAnimal);
+        if (TaxesModule.PlayerShouldPayTaxes)
+        {
+            Game1.player.Increment(DataFields.BusinessExpenses, ___priceOfAnimal);
+        }
+        else
+        {
+            ModEntry.Broadcaster.MessageHost(___priceOfAnimal.ToString(), "Taxes." + DataFields.BusinessExpenses);
+        }
     }
 
     #endregion harmony patches

--- a/Modular Gameplay Overhaul/Modules/Taxes/Patchers/ShopMenuTryToPurchaseItemPatcher.cs
+++ b/Modular Gameplay Overhaul/Modules/Taxes/Patchers/ShopMenuTryToPurchaseItemPatcher.cs
@@ -91,7 +91,14 @@ internal sealed class ShopMenuTryToPurchaseItemPatcher : HarmonyPatcher
             }
         }
 
-        Game1.player.Increment(DataFields.BusinessExpenses, menu.itemPriceAndStock[item][0]);
+        if (TaxesModule.PlayerShouldPayTaxes)
+        {
+            Game1.player.Increment(DataFields.BusinessExpenses, menu.itemPriceAndStock[item][0]);
+        }
+        else
+        {
+            ModEntry.Broadcaster.MessageHost(menu.itemPriceAndStock[item][0].ToString(), "Taxes." + DataFields.BusinessExpenses);
+        }
     }
 
     #endregion harmony patches


### PR DESCRIPTION
I have been having troubles with the Taxes module when playing multiplayer using shared wallets. The root issue seemed to be that all farmers would be taxed based on the same shared farm income, while expenses and deductions were only taking the individual farmer into account. That resulted in huge taxes after each season, upwards of 50%, typically wiping out all our money and incurring a significant debt.

In order to correct that behavior, I added logic to allow non-taxable farmhands, that is farmhands using a shared wallet with the host in multiplayer. They do not perform any tax calculations and instead message the host for any deductible expenses. Income is already handled correctly by the host so there was no need to modify that. This does not handle Conservationist deductions, but the existing logic doesn't either so there is no functional change to that.