### PR TITLE
Ownership issue with crab pot profession perks during multiplayer

### DIFF
--- a/Modular Gameplay Overhaul/Modules/Professions/Patchers/Fishing/CrabPotDayUpdatePatcher.cs
+++ b/Modular Gameplay Overhaul/Modules/Professions/Patchers/Fishing/CrabPotDayUpdatePatcher.cs
@@ -31,8 +31,10 @@ internal sealed class CrabPotDayUpdatePatcher : HarmonyPatcher
     {
         try
         {
-            var owner = ProfessionsModule.Config.LaxOwnershipRequirements ? Game1.player : __instance.GetOwner();
-            var isConservationist = owner.HasProfession(Profession.Conservationist);
+            var owner = __instance.GetOwner();
+            var isConservationist = ProfessionsModule.Config.LaxOwnershipRequirements
+                ? Game1.game1.DoesAnyPlayerHaveProfession(Profession.Conservationist, out _)
+                : owner.HasProfession(Profession.Conservationist);
             if ((__instance.bait.Value is null && !isConservationist) || __instance.heldObject.Value is not null)
             {
                 return false; // don't run original logic
@@ -41,7 +43,9 @@ internal sealed class CrabPotDayUpdatePatcher : HarmonyPatcher
             var r = new Random(Guid.NewGuid().GetHashCode());
             var fishData =
                 Game1.content.Load<Dictionary<int, string>>(PathUtilities.NormalizeAssetName("Data/Fish"));
-            var isLuremaster = owner.HasProfession(Profession.Luremaster);
+            var isLuremaster = ProfessionsModule.Config.LaxOwnershipRequirements
+                ? Game1.game1.DoesAnyPlayerHaveProfession(Profession.Luremaster, out _)
+                : owner.HasProfession(Profession.Luremaster);
             var whichFish = -1;
             if (__instance.bait.Value is not null)
             {


### PR DESCRIPTION
While playing multiplayer, a farmhand chose the Luremaster profession, but we noticed it never seemed to work. I reviewed the code, added some debug logging, and noticed that the CrabPotDayUpdatePrefix seems to only ever run on the host game. This causes the profession checks to only work if the host has the required professions, ignoring the object owner and other farmhands, even with lax ownership enabled. I modified the ownership and lax ownership checks to be similar to what other professions use. It seems to be handling the crab pots correctly now during our game, both with and without lax ownership enabled.